### PR TITLE
Update GDOverlay.swift

### DIFF
--- a/Sources/SwiftyOverlay/GDOverlay.swift
+++ b/Sources/SwiftyOverlay/GDOverlay.swift
@@ -457,7 +457,7 @@ extension GDOverlay{
             return 3
         } else if targetPoint.x > centerPoint.x && targetPoint.y < centerPoint.y {
             return 2
-        } else if targetPoint.x > centerPoint.x && targetPoint.y > centerPoint.y {
+        } else if targetPoint.x >= centerPoint.x && targetPoint.y > centerPoint.y {
             return 4
         } else {
             return 1


### PR DESCRIPTION
Fixed bug where when view is near bottom of screen and in the middle, the arrow points to the wrong side.